### PR TITLE
Chore: Improve Docker Image Size / Dockerfile

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -15,25 +15,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   locales \
   python3 \
   python3-pip \
-  wget \
+  python3-setuptools \
+  python3-dev \
   pkg-config\
-  curl \
   cuda-command-line-tools-10-0 \
   cuda-cublas-10-0 \
   cuda-cufft-10-0 \
   cuda-curand-10-0 \
   cuda-cusolver-10-0 \
-  cuda-cusparse-10-0
+  cuda-cusparse-10-0 \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    rm get-pip.py
-
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Set the locale (required for uvicorn)
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -40,4 +40,6 @@ ENV LANG en_US.UTF-8
 
 WORKDIR /main
 
+EXPOSE 4343
+
 CMD ["uvicorn", "start:app", "--host", "0.0.0.0", "--port", "4343"]


### PR DESCRIPTION
This PR improves the size of the docker image by removing some cache files, unused packages.

```
docker images | ack tensorflow_inference              
tensorflow_inference_api_gpu   improved                [...]      1.93GB
tensorflow_inference_api_gpu   upstream                [...]      2.17GB
```

Where `tensorflow_inference_api_gpu:upstream` is the original image and `tensorflow_inference_api_gpu:improved` is the one from this PR.

I've added `python3-setuptools` and `python3-dev` which makes it possible to use the distribution's pip package. By doing so I was able to remove the non-default installation of pip via `https://bootstrap.pypa.io/get-pip.py`. I would recommend to go with the distribution's pip package. In case this is not sufficient I would suggest to at least compare the checksum of the downloaded package against a known checksum due to security reasons.

I also added the exposed ports, which is [good practice and serves as a documentation](https://docs.docker.com/engine/reference/builder/#expose).

Also please note that I do not have a NVIDIA GPU at hand, so you want to make sure that this image still works as expected before merging the PR.